### PR TITLE
Switch rating algorithm to linear

### DIFF
--- a/Benchmarking/BenchmarkRater.cs
+++ b/Benchmarking/BenchmarkRater.cs
@@ -1,19 +1,29 @@
-﻿using System;
+﻿#region using
+
+using System;
+
+#endregion
 
 namespace Benchmarking
 {
 	public static class BenchmarkRater
 	{
 		// Maybe replace with linear rating?
-		public static double RateBenchmark(double timeInMillis)
+		public static double RateBenchmark(double timeInMillis, double referenceTimeInMillis)
 		{
-			// Maximum 1000000 points (100k)
-			const double maxTime = 100000;
+			const int baseline = 50000;
 
-			// "Maximum" of 10000000 (1M) milliseconds or 1000 seconds
+			if (timeInMillis > referenceTimeInMillis)
+			{
+				return Math.Round(-0.5 * timeInMillis + baseline, 0);
+			}
 
-			// Nice exponential graph from x = 0 to x ~ 1000000 and
-			return Math.Round(maxTime * Math.Pow(0.5, 0.00001 * timeInMillis), 0);
+			if (timeInMillis < referenceTimeInMillis)
+			{
+				return Math.Round(-0.5 * timeInMillis + baseline, 0) + baseline;
+			}
+
+			return baseline;
 		}
 	}
 }

--- a/Benchmarking/BenchmarkRunner.cs
+++ b/Benchmarking/BenchmarkRunner.cs
@@ -228,8 +228,10 @@ namespace Benchmarking
 				var timing = ExecuteBenchmark();
 
 				Results.Add(new Result(benchmarksToRun[0].GetDescription(), timing,
-					BenchmarkRater.RateBenchmark(timing), benchmarksToRun[0].GetReferenceValue(),
-					BenchmarkRater.RateBenchmark(benchmarksToRun[0].GetReferenceValue())));
+					BenchmarkRater.RateBenchmark(timing, benchmarksToRun[0].GetReferenceValue()),
+					benchmarksToRun[0].GetReferenceValue(),
+					BenchmarkRater.RateBenchmark(benchmarksToRun[0].GetReferenceValue(),
+						benchmarksToRun[0].GetReferenceValue())));
 
 				benchmarksToRun.RemoveAt(0);
 				GC.Collect();


### PR DESCRIPTION
Closes #36
Marks the R9 3900x as baseline at 50k points and then just assigns points around it.
This make the whole rating depend on the reference value rather than the relative time difference (as before), which is IMO a clearer rating and with the timing is pretty transparent