### PR TITLE
Update points and unify reference values into MT value

### DIFF
--- a/Benchmarking/Arithmetic/Float.cs
+++ b/Benchmarking/Arithmetic/Float.cs
@@ -92,11 +92,6 @@ namespace Benchmarking.Arithmetic
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 7780.0d;
-			}
-
 			return 308.0d;
 		}
 

--- a/Benchmarking/Arithmetic/Float.cs
+++ b/Benchmarking/Arithmetic/Float.cs
@@ -90,6 +90,21 @@ namespace Benchmarking.Arithmetic
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 8689.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 308.0d;

--- a/Benchmarking/Arithmetic/Integer.cs
+++ b/Benchmarking/Arithmetic/Integer.cs
@@ -196,6 +196,21 @@ namespace Benchmarking.Arithmetic
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 15464.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 596.0d;

--- a/Benchmarking/Arithmetic/Integer.cs
+++ b/Benchmarking/Arithmetic/Integer.cs
@@ -10,8 +10,8 @@ namespace Benchmarking.Arithmetic
 {
 	internal class Integer : Benchmark
 	{
-		// 200 "MB"
-		private const int LENGTH = 200000000;
+		// 100 "MB"
+		private const int LENGTH = 100000000;
 		private byte[] resultByteArray;
 		private int[] resultIntArray;
 		private long[] resultLongArray;
@@ -198,12 +198,7 @@ namespace Benchmarking.Arithmetic
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 27743.0d;
-			}
-
-			return 1083.0d;
+			return 596.0d;
 		}
 
 		public override string GetDescription()

--- a/Benchmarking/Benchmark.cs
+++ b/Benchmarking/Benchmark.cs
@@ -22,6 +22,11 @@
 		{
 		}
 
+		public virtual double GetComparison()
+		{
+			return GetReferenceValue();
+		}
+
 		public virtual double GetReferenceValue()
 		{
 			return 0.0d;
@@ -39,7 +44,7 @@
 
 		public virtual string GetName()
 		{
-			return this.GetType().Name;
+			return GetType().Name;
 		}
 	}
 }

--- a/Benchmarking/Compression/BZip2.cs
+++ b/Benchmarking/Compression/BZip2.cs
@@ -67,9 +67,13 @@ namespace Benchmarking.Compression
 		{
 			switch (options.Threads)
 			{
+				case 1:
+				{
+					return 8590.0d;
+				}
 				default:
 				{
-					return GetReferenceValue();
+					return base.GetComparison();
 				}
 			}
 		}

--- a/Benchmarking/Compression/BZip2.cs
+++ b/Benchmarking/Compression/BZip2.cs
@@ -63,6 +63,17 @@ namespace Benchmarking.Compression
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				default:
+				{
+					return GetReferenceValue();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 5727.0d;

--- a/Benchmarking/Compression/BZip2.cs
+++ b/Benchmarking/Compression/BZip2.cs
@@ -29,15 +29,12 @@ namespace Benchmarking.Compression
 				{
 					using (Stream s = new MemoryStream())
 					{
-						using (var stream = new BZip2OutputStream(s))
-						{
-							using (var sw = new StreamWriter(stream))
-							{
-								sw.Write(datas[i1]);
-								sw.Flush();
-								stream.Flush();
-							}
-						}
+						using var stream = new BZip2OutputStream(s);
+						using var sw = new StreamWriter(stream);
+
+						sw.Write(datas[i1]);
+						sw.Flush();
+						stream.Flush();
 					}
 
 					BenchmarkRunner.ReportProgress(GetName());
@@ -49,19 +46,19 @@ namespace Benchmarking.Compression
 
 		public override string GetDescription()
 		{
-			return "Compressing 1 GB of data with BZip2";
+			return "Compressing 128 MB of data with BZip2";
 		}
 
 		public override void Initialize()
 		{
 			var tasks = new Task[options.Threads];
 
-			// 500 "MB" string -> 2 bytes per character -> 1 GB String
+			// 64 "MB" string -> 2 bytes per character -> 128 MB String
 			for (var i = 0; i < options.Threads; i++)
 			{
 				var i1 = i;
-
-				tasks[i1] = Task.Run(() => { datas[i1] = DataGenerator.GenerateString((int) (500000000 / options.Threads)); });
+				// 500000000
+				tasks[i1] = Task.Run(() => { datas[i1] = DataGenerator.GenerateString((int) (64000000 / options.Threads)); });
 			}
 
 			Task.WaitAll(tasks);
@@ -69,12 +66,7 @@ namespace Benchmarking.Compression
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 58569.0d;
-			}
-
-			return 7938.0d;
+			return 5727.0d;
 		}
 		public override string GetCategory()
 		{

--- a/Benchmarking/Compression/Brotli.cs
+++ b/Benchmarking/Compression/Brotli.cs
@@ -1,5 +1,6 @@
 ﻿#region using
 
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using Benchmarking.Util;
 
 namespace Benchmarking.Compression
 {
+	[Obsolete]
 	internal class Brotli : Benchmark
 	{
 		private readonly string[] datas;

--- a/Benchmarking/Compression/Deflate.cs
+++ b/Benchmarking/Compression/Deflate.cs
@@ -65,6 +65,21 @@ namespace Benchmarking.Compression
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 25783.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 3700.0d;

--- a/Benchmarking/Compression/Deflate.cs
+++ b/Benchmarking/Compression/Deflate.cs
@@ -30,15 +30,12 @@ namespace Benchmarking.Compression
 				{
 					using (Stream s = new MemoryStream())
 					{
-						using (var stream = new DeflaterOutputStream(s, new Deflater(Deflater.BEST_COMPRESSION)))
-						{
-							using (var sw = new StreamWriter(stream))
-							{
-								sw.Write(datas[i1]);
-								sw.Flush();
-								stream.Finish();
-							}
-						}
+						using var stream = new DeflaterOutputStream(s, new Deflater(Deflater.BEST_COMPRESSION));
+						using var sw = new StreamWriter(stream);
+
+						sw.Write(datas[i1]);
+						sw.Flush();
+						stream.Finish();
 					}
 
 					BenchmarkRunner.ReportProgress(GetName());
@@ -70,12 +67,7 @@ namespace Benchmarking.Compression
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 23083.0d;
-			}
-
-			return 2556.0d;
+			return 3700.0d;
 		}
 		public override string GetCategory()
 		{

--- a/Benchmarking/Compression/GZip.cs
+++ b/Benchmarking/Compression/GZip.cs
@@ -68,6 +68,21 @@ namespace Benchmarking.Compression
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 29511.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 3800.0d;

--- a/Benchmarking/Compression/GZip.cs
+++ b/Benchmarking/Compression/GZip.cs
@@ -29,17 +29,13 @@ namespace Benchmarking.Compression
 				{
 					using (Stream s = new MemoryStream())
 					{
-						using (var stream = new GZipOutputStream(s))
-						{
-							stream.SetLevel(9);
+						using var stream = new GZipOutputStream(s);
+						stream.SetLevel(9);
 
-							using (var sw = new StreamWriter(stream))
-							{
-								sw.Write(datas[i1]);
-								sw.Flush();
-								stream.Finish();
-							}
-						}
+						using var sw = new StreamWriter(stream);
+						sw.Write(datas[i1]);
+						sw.Flush();
+						stream.Finish();
 					}
 
 					BenchmarkRunner.ReportProgress(GetName());
@@ -63,7 +59,10 @@ namespace Benchmarking.Compression
 			{
 				var i1 = i;
 
-				tasks[i1] = Task.Run(() => { datas[i1] = DataGenerator.GenerateString((int) (500000000 / options.Threads)); });
+				tasks[i1] = Task.Run(() =>
+				{
+					datas[i1] = DataGenerator.GenerateString((int) (500000000 / options.Threads));
+				});
 			}
 
 			Task.WaitAll(tasks);
@@ -71,13 +70,9 @@ namespace Benchmarking.Compression
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 24658.0d;
-			}
-
-			return 2673.0d;
+			return 3800.0d;
 		}
+
 		public override string GetCategory()
 		{
 			return "compression";

--- a/Benchmarking/Compression/ZIP.cs
+++ b/Benchmarking/Compression/ZIP.cs
@@ -71,6 +71,21 @@ namespace Benchmarking.Compression
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 27676.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 2675.0d;

--- a/Benchmarking/Compression/ZIP.cs
+++ b/Benchmarking/Compression/ZIP.cs
@@ -73,11 +73,6 @@ namespace Benchmarking.Compression
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 24878.0d;
-			}
-
 			return 2675.0d;
 		}
 

--- a/Benchmarking/Cryptography/CSPRNG.cs
+++ b/Benchmarking/Cryptography/CSPRNG.cs
@@ -38,16 +38,11 @@ namespace Benchmarking.Cryptography
 
 		public override string GetDescription()
 		{
-			return "Generates 1GB of secure random data 64 times";
+			return "Generates 1GB of cryptographically secure random data 64 times";
 		}
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 17563.0d;
-			}
-
 			return 4004.0d;
 		}
 

--- a/Benchmarking/Cryptography/CSPRNG.cs
+++ b/Benchmarking/Cryptography/CSPRNG.cs
@@ -41,6 +41,21 @@ namespace Benchmarking.Cryptography
 			return "Generates 1GB of cryptographically secure random data 64 times";
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 17329.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 4004.0d;

--- a/Benchmarking/Cryptography/Decryption.cs
+++ b/Benchmarking/Cryptography/Decryption.cs
@@ -43,24 +43,19 @@ namespace Benchmarking.Cryptography
 				{
 					using (Stream s = new MemoryStream())
 					{
-						using (var stream = new CryptoStream(s, new HMACSHA512(sha512Key),
-							CryptoStreamMode.Read))
-						{
-							using (var sw = new StreamWriter(s))
-							{
-								sw.Write(datasSHA[i1]);
-								sw.Flush();
-								stream.Flush();
-								stream.FlushFinalBlock();
+						using var stream = new CryptoStream(s, new HMACSHA512(sha512Key),
+							CryptoStreamMode.Read);
+						using var sw = new StreamWriter(s);
 
-								s.Seek(0, SeekOrigin.Begin);
+						sw.Write(datasSHA[i1]);
+						sw.Flush();
+						stream.Flush();
+						stream.FlushFinalBlock();
 
-								using (var sr = new StreamReader(stream))
-								{
-									datasSHA[i1] = sr.ReadToEnd();
-								}
-							}
-						}
+						s.Seek(0, SeekOrigin.Begin);
+
+						using var sr = new StreamReader(stream);
+						datasSHA[i1] = sr.ReadToEnd();
 					}
 
 					using (var aes = new AesGcm(aesKey))
@@ -113,13 +108,11 @@ namespace Benchmarking.Cryptography
 
 					aesPlaintext[i1] = new byte[Encoding.UTF8.GetBytes(datas[i1]).Length];
 
-					using (var aes = new AesGcm(aesKey))
-					{
-						datasAES[i1] = new byte[datas[i1].Length];
-						aesTag[i1] = new byte[16];
+					using var aes = new AesGcm(aesKey);
+					datasAES[i1] = new byte[datas[i1].Length];
+					aesTag[i1] = new byte[16];
 
-						aes.Encrypt(aesNonce, Encoding.UTF8.GetBytes(datas[i1]), datasAES[i1], aesTag[i1]);
-					}
+					aes.Encrypt(aesNonce, Encoding.UTF8.GetBytes(datas[i1]), datasAES[i1], aesTag[i1]);
 				});
 			}
 
@@ -128,13 +121,9 @@ namespace Benchmarking.Cryptography
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 225.0d;
-			}
-
 			return 64.0d;
 		}
+
 		public override string GetCategory()
 		{
 			return "cryptography";

--- a/Benchmarking/Cryptography/Decryption.cs
+++ b/Benchmarking/Cryptography/Decryption.cs
@@ -119,6 +119,21 @@ namespace Benchmarking.Cryptography
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 270.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 64.0d;

--- a/Benchmarking/Cryptography/Encryption.cs
+++ b/Benchmarking/Cryptography/Encryption.cs
@@ -87,11 +87,6 @@ namespace Benchmarking.Cryptography
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 2028.0d;
-			}
-
 			return 548.0d;
 		}
 		public override string GetCategory()

--- a/Benchmarking/Cryptography/Encryption.cs
+++ b/Benchmarking/Cryptography/Encryption.cs
@@ -85,6 +85,21 @@ namespace Benchmarking.Cryptography
 			RandomNumberGenerator.Fill(aesKey);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 2004.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 548.0d;

--- a/Benchmarking/Decompression/BZip2.cs
+++ b/Benchmarking/Decompression/BZip2.cs
@@ -48,14 +48,14 @@ namespace Benchmarking.Decompression
 
 		public override string GetDescription()
 		{
-			return "Decompressing 1 GB of data with BZip2";
+			return "Decompressing 512 MB of data with BZip2";
 		}
 
 		public override void Initialize()
 		{
 			var tasks = new Task[options.Threads];
 
-			// 500 "MB" string -> 2 bytes per character -> 1 GB String
+			// 256 "MB" string -> 2 bytes per character -> 512 MB String
 			for (var i = 0; i < options.Threads; i++)
 			{
 				var i1 = i;
@@ -63,23 +63,21 @@ namespace Benchmarking.Decompression
 				tasks[i1] = Task.Run(() =>
 				{
 					// 500000000
-					var data = DataGenerator.GenerateString((int) (500000000 / options.Threads));
+					var data = DataGenerator.GenerateString((int) (256000000 / options.Threads));
 
-					using (var s = new MemoryStream())
+					using var s = new MemoryStream();
+					using (var stream = new BZip2OutputStream(s))
 					{
-						using (var stream = new BZip2OutputStream(s))
-						{
-							using var sw = new StreamWriter(stream);
-							sw.Write(data);
-							sw.Flush();
+						using var sw = new StreamWriter(stream);
+						sw.Write(data);
+						sw.Flush();
 
-							stream.IsStreamOwner = false;
-						}
-
-						s.Seek(0, SeekOrigin.Begin);
-
-						datas[i1] = s.ToArray();
+						stream.IsStreamOwner = false;
 					}
+
+					s.Seek(0, SeekOrigin.Begin);
+
+					datas[i1] = s.ToArray();
 				});
 			}
 
@@ -88,12 +86,7 @@ namespace Benchmarking.Decompression
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 32432.0d;
-			}
-
-			return 9355.0d;
+			return 5104.0d;
 		}
 
 		public override string GetCategory()

--- a/Benchmarking/Decompression/BZip2.cs
+++ b/Benchmarking/Decompression/BZip2.cs
@@ -84,6 +84,21 @@ namespace Benchmarking.Decompression
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 19389.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 5104.0d;

--- a/Benchmarking/Decompression/Deflate.cs
+++ b/Benchmarking/Decompression/Deflate.cs
@@ -1,6 +1,5 @@
 ﻿#region using
 
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Benchmarking.Util;
@@ -67,22 +66,20 @@ namespace Benchmarking.Decompression
 					// 500000000
 					var data = DataGenerator.GenerateString((int) (500000000 / options.Threads));
 
-					using (var s = new MemoryStream())
+					using var s = new MemoryStream();
+					using (var stream = new DeflaterOutputStream(s, new Deflater(Deflater.BEST_COMPRESSION)))
 					{
-						using (var stream = new DeflaterOutputStream(s, new Deflater(Deflater.BEST_COMPRESSION)))
-						{
-							using var sw = new StreamWriter(stream);
-							sw.Write(data);
-							sw.Flush();
-							stream.Finish();
+						using var sw = new StreamWriter(stream);
+						sw.Write(data);
+						sw.Flush();
+						stream.Finish();
 
-							stream.IsStreamOwner = false;
-						}
-
-						s.Seek(0, SeekOrigin.Begin);
-
-						datas[i1] = s.ToArray();
+						stream.IsStreamOwner = false;
 					}
+
+					s.Seek(0, SeekOrigin.Begin);
+
+					datas[i1] = s.ToArray();
 				});
 			}
 
@@ -91,11 +88,6 @@ namespace Benchmarking.Decompression
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 5866.0d;
-			}
-
 			return 3463.0d;
 		}
 

--- a/Benchmarking/Decompression/Deflate.cs
+++ b/Benchmarking/Decompression/Deflate.cs
@@ -86,6 +86,21 @@ namespace Benchmarking.Decompression
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 6666.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 3463.0d;

--- a/Benchmarking/Decompression/GZip.cs
+++ b/Benchmarking/Decompression/GZip.cs
@@ -1,6 +1,5 @@
 ﻿#region using
 
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Benchmarking.Util;
@@ -66,24 +65,22 @@ namespace Benchmarking.Decompression
 					// 500000000
 					var data = DataGenerator.GenerateString((int) (500000000 / options.Threads));
 
-					using (var s = new MemoryStream())
+					using var s = new MemoryStream();
+					using (var stream = new GZipOutputStream(s))
 					{
-						using (var stream = new GZipOutputStream(s))
-						{
-							stream.SetLevel(9);
+						stream.SetLevel(9);
 
-							using var sw = new StreamWriter(stream);
-							sw.Write(data);
-							sw.Flush();
-							stream.Finish();
+						using var sw = new StreamWriter(stream);
+						sw.Write(data);
+						sw.Flush();
+						stream.Finish();
 
-							stream.IsStreamOwner = false;
-						}
-
-						s.Seek(0, SeekOrigin.Begin);
-
-						datas[i1] = s.ToArray();
+						stream.IsStreamOwner = false;
 					}
+
+					s.Seek(0, SeekOrigin.Begin);
+
+					datas[i1] = s.ToArray();
 				});
 			}
 
@@ -92,11 +89,6 @@ namespace Benchmarking.Decompression
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 7279.0d;
-			}
-
 			return 3598.0d;
 		}
 

--- a/Benchmarking/Decompression/GZip.cs
+++ b/Benchmarking/Decompression/GZip.cs
@@ -87,6 +87,21 @@ namespace Benchmarking.Decompression
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 8151.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 3598.0d;

--- a/Benchmarking/Decompression/ZIP.cs
+++ b/Benchmarking/Decompression/ZIP.cs
@@ -30,19 +30,16 @@ namespace Benchmarking.Decompression
 				{
 					using (Stream s = new MemoryStream())
 					{
-						using (var sw = new StreamWriter(s))
-						{
+						using var sw = new StreamWriter(s);
+						sw.Write(datas[i1]);
+						sw.Flush();
 
-							sw.Write(datas[i1]);
-							sw.Flush();
+						s.Seek(0, SeekOrigin.Begin);
 
-							s.Seek(0, SeekOrigin.Begin);
+						using var stream = new ZipInputStream(s);
+						var zipEntry = stream.GetNextEntry();
 
-							using var stream = new ZipInputStream(s);
-							var zipEntry = stream.GetNextEntry();
-
-							zipEntry.DateTime = DateTime.Now;
-						}
+						zipEntry.DateTime = DateTime.Now;
 					}
 
 					BenchmarkRunner.ReportProgress(GetName());
@@ -80,7 +77,6 @@ namespace Benchmarking.Decompression
 					{
 						using (var stream = new ZipOutputStream(s))
 						{
-
 							stream.SetLevel(9);
 
 							var entry = new ZipEntry("test.txt") {DateTime = DateTime.Now};
@@ -110,11 +106,6 @@ namespace Benchmarking.Decompression
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 1864.0d;
-			}
-
 			return 256.0d;
 		}
 

--- a/Benchmarking/Decompression/ZIP.cs
+++ b/Benchmarking/Decompression/ZIP.cs
@@ -104,6 +104,21 @@ namespace Benchmarking.Decompression
 			Task.WaitAll(tasks);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 1940.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 256.0d;

--- a/Benchmarking/Extension/AVX.cs
+++ b/Benchmarking/Extension/AVX.cs
@@ -60,7 +60,7 @@ namespace Benchmarking.Extension
 
 		public override string GetDescription()
 		{
-			return "AVX benchmark of addition and multiplication on 512 floats (2048 bits)";
+			return "AVX benchmark of addition and multiplication on 512 floats (2048 bits) 1.000.000.000 times.";
 		}
 
 		public override void Initialize()
@@ -73,6 +73,21 @@ namespace Benchmarking.Extension
 			{
 				// Multiple of 256 to test AVX only
 				datas.Add(new float[512]);
+			}
+		}
+
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 93645.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
 			}
 		}
 

--- a/Benchmarking/Extension/AVX.cs
+++ b/Benchmarking/Extension/AVX.cs
@@ -60,7 +60,7 @@ namespace Benchmarking.Extension
 
 		public override string GetDescription()
 		{
-			return "AVX benchmark with big vectors";
+			return "AVX benchmark of addition and multiplication on 512 floats (2048 bits)";
 		}
 
 		public override void Initialize()
@@ -72,18 +72,13 @@ namespace Benchmarking.Extension
 			for (var i = 0; i < options.Threads; i++)
 			{
 				// Multiple of 256 to test AVX only
-				datas.Add(new float[1024]);
+				datas.Add(new float[512]);
 			}
 		}
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 164184.0d;
-			}
-
-			return 24795.0d;
+			return 14306.0d;
 		}
 
 #if NETCOREAPP3_0

--- a/Benchmarking/Extension/SSE.cs
+++ b/Benchmarking/Extension/SSE.cs
@@ -42,7 +42,7 @@ namespace Benchmarking.Extension
 					var randomFloatingSpan = new Span<float>(new[] { randomFloatingNumber });
 					var dst = new Span<float>(datas[i1]);
 
-					var iterations = 1000000000 / options.Threads;
+					var iterations = 100000000 / options.Threads;
 
 					for (var j = 0; j < iterations; j++)
 					{
@@ -60,7 +60,7 @@ namespace Benchmarking.Extension
 
 		public override string GetDescription()
 		{
-			return "SSE benchmark of addition and multiplication on 256 floats (1024 bits)";
+			return "SSE benchmark of addition and multiplication on 256 floats (1024 bits) 100.000.000 times.";
 		}
 
 		public override void Initialize()
@@ -76,9 +76,24 @@ namespace Benchmarking.Extension
 			}
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 17154.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
-			return 36931.0d;
+			return 3440.0d;
 		}
 
 #if NETCOREAPP3_0

--- a/Benchmarking/Extension/SSE.cs
+++ b/Benchmarking/Extension/SSE.cs
@@ -60,7 +60,7 @@ namespace Benchmarking.Extension
 
 		public override string GetDescription()
 		{
-			return "SSE benchmark by adding two vectors of 128 bit (4 floats) from a big vector of 512 floats";
+			return "SSE benchmark of addition and multiplication on 256 floats (1024 bits)";
 		}
 
 		public override void Initialize()
@@ -71,19 +71,14 @@ namespace Benchmarking.Extension
 
 			for (var i = 0; i < options.Threads; i++)
 			{
-				// Multiple of 256 to test AVX only
-				datas.Add(new float[512]);
+				// Multiple of 128 to test SSE only
+				datas.Add(new float[256]);
 			}
 		}
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 423293.0d;
-			}
-
-			return 49363.0d;
+			return 36931.0d;
 		}
 
 #if NETCOREAPP3_0

--- a/Benchmarking/Parsing/HTMLParser.cs
+++ b/Benchmarking/Parsing/HTMLParser.cs
@@ -38,6 +38,21 @@ namespace Benchmarking.Parsing
 			Task.WaitAll(threads);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 1027.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 1266.0d;

--- a/Benchmarking/Parsing/HTMLParser.cs
+++ b/Benchmarking/Parsing/HTMLParser.cs
@@ -40,12 +40,7 @@ namespace Benchmarking.Parsing
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 7371.0d;
-			}
-
-			return 7776.0d;
+			return 1266.0d;
 		}
 
 		public override string GetCategory()
@@ -65,7 +60,7 @@ namespace Benchmarking.Parsing
 				{
 					var document = new HtmlDocument();
 
-					for (var j = 0; j < 500000 / options.Threads; j++)
+					for (var j = 0; j < 100000 / options.Threads; j++)
 					{
 						document.DocumentNode.AppendChild(document.CreateElement("input"));
 						document.DocumentNode.AppendChild(document.CreateElement("div").AppendChild(document

--- a/Benchmarking/Parsing/JSONParser.cs
+++ b/Benchmarking/Parsing/JSONParser.cs
@@ -40,12 +40,7 @@ namespace Benchmarking.Parsing
 
 		public override double GetReferenceValue()
 		{
-			if (options.Threads == 1)
-			{
-				return 1538.0d;
-			}
-
-			return 702.0d;
+			return 1141.0d;
 		}
 
 		public override string GetCategory()

--- a/Benchmarking/Parsing/JSONParser.cs
+++ b/Benchmarking/Parsing/JSONParser.cs
@@ -38,6 +38,21 @@ namespace Benchmarking.Parsing
 			Task.WaitAll(threads);
 		}
 
+		public override double GetComparison()
+		{
+			switch (options.Threads)
+			{
+				case 1:
+				{
+					return 2095.0d;
+				}
+				default:
+				{
+					return base.GetComparison();
+				}
+			}
+		}
+
 		public override double GetReferenceValue()
 		{
 			return 1141.0d;

--- a/Benchmarking/Results/ResultSaver.cs
+++ b/Benchmarking/Results/ResultSaver.cs
@@ -37,7 +37,7 @@ namespace Benchmarking.Results
 			// Skip checks if they only want to view their results
 			if (!options.ListResults)
 			{
-				var machineInformation = MachineInformationGatherer.GatherInformation(false);
+				var machineInformation = MachineInformationGatherer.GatherInformation();
 
 				if (!CheckValidSave(machineInformation))
 				{
@@ -93,6 +93,15 @@ namespace Benchmarking.Results
 		{
 			try
 			{
+				var machineInformation = MachineInformationGatherer.GatherInformation(false);
+
+				if (!CheckValidSave(machineInformation))
+				{
+					return false;
+				}
+
+				save.MachineInformation = machineInformation;
+
 				var uuid = await ResultUploader.UploadResult(save).ConfigureAwait(false);
 
 				save.UUID = uuid;


### PR DESCRIPTION
The general point of this change is:
1. "Speed up" the benchmark so an all-run won't take an hour
2. Unify the scoring so ST isn't rated at 50k points like MT, and thus an actual ratio could be calculated based on points

- [x] List some reference values in various core configurations for the benchmarks, in order to get an actual reference in the console, instead of just the MT performance, which would be displayed even if the benchmark was run in ST.